### PR TITLE
Remove trailing whitespace from boilerplate

### DIFF
--- a/python/build_templates.py
+++ b/python/build_templates.py
@@ -7,9 +7,9 @@ from collections import OrderedDict
 
 script_path = os.path.dirname(os.path.abspath(__file__))
 
-cpp_header = """/* 
+cpp_header = """/*
  * LSST Data Management System
- * 
+ *
  * This product includes software developed by the
  * LSST Project (http://www.lsst.org/).
  * See the COPYRIGHT file
@@ -18,14 +18,14 @@ cpp_header = """/*
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the LSST License Statement and 
- * the GNU General Public License along with this program.  If not, 
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
  * see <https://www.lsstcorp.org/LegalNotices/>.
  */
 """


### PR DESCRIPTION
While there's nothing in the LSST C++ standards that forbids trailing whitespace, git doesn't like it, so it's best to leave it out.