### PR TITLE
tickets/DM-8810: Deprecate dmtn-026

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -6,7 +6,15 @@
 
 .. warning::
 
-    This document has been superseded by the pybind11 information in the `LSST DM Developer Guide <https://developer.lsst.io>`_.
+    This document was used to assist in porting the stack from SWIG to pybind11.
+    Now that the merge has been completed (`DM-8467 <https://jira.lsstcorp.org/browse/DM-8467>`_),
+    this document exists as a historical record only and should not be used for future development.
+    
+    Date deprecated: 2017-03-16
+    
+    Replacement Links:
+    
+    - `DM Developer Guide: Python wrappers for C++ with pybind11 <https://developer.lsst.io/coding/python_wrappers_for_cpp_with_pybind11.html>`_
 
 .. _scope:
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -56,3 +56,12 @@ docushare_url: ''
 
 # GitHub repo URL
 github_url: 'https://github.com/lsst-dm/dmtn-026'
+
+# This technote is deprecated as of the merging of DM-8467,
+# which implemented pybind11 in place of SWIG on master
+deprecation:
+  date: 2017-03-16
+  message: >-
+    A sentence or two explaining the deprecation.
+  replacements:
+    - {"name": "DM Developer Guide: Python wrappers for C++ with pybind11", "url": "https://developer.lsst.io/coding/python_wrappers_for_cpp_with_pybind11.html"}


### PR DESCRIPTION
During the pybind11 port a convenience script was helpful to create templates for all of the
header files. Now that the port is complete, this script is no longer needed.